### PR TITLE
RELENG-2330 Replace the legacy /repo prefix in the Artifactory URL

### DIFF
--- a/VerimiLogin/pom.xml
+++ b/VerimiLogin/pom.xml
@@ -12,7 +12,7 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions copyright [year] [name of copyright owner]".
  *
- * Copyright 2017-2018 ForgeRock AS.
+ * Copyright 2017-2023 ForgeRock AS.
  * 
 -->
 
@@ -117,7 +117,7 @@
             </snapshots>
             <id>forgerock-private-releases</id>
             <name>ForgeRock Private Release Repository</name>
-            <url>http://maven.forgerock.org/repo/private-releases</url>
+            <url>https://maven.forgerock.org/artifactory/private-releases</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Hi,
The ForgeRock Artifactory instance will soon move to the JFrog.io SaaS.
The URL will remain the same but the /repo prefix won't work anymore.
Thanks,
Bruno Lavit, release manager at ForgeRock